### PR TITLE
Add gas related call options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,13 @@
 ### Features
 
 * Add `repl.block()`
-* Allow to customize `block` through call options
-* Allow to customize `from` through call options
+* Allow to customize more variables through call options:
+  * `block` - block number to use for the call
+  * `from` - address to use as `msg.sender`
+  * `gasLimit` - gas limit to use for the transaction
+  * `maxFee` - maximum fee to pay for the transaction
+  * `priorityFee` - priority fee to pay for the transaction
+  * `gasPrice` - gas price to use for the (legacy) transaction
 * Allow to select version of Eclair when installing using install script
 
 ## 0.1.1 (2024-07-30)

--- a/docs/src/interacting_with_contracts.md
+++ b/docs/src/interacting_with_contracts.md
@@ -42,6 +42,10 @@ The following options are currently supported:
 * `value`: sets the `msg.value` of the transaction
 * `block`: sets the block number to execute the call on (only works for calls, not for sending transactions)
 * `from`: sets the `from` for the call (only works for calls, not for sending transactions)
+* `gasLimit`: sets the gas limit to use for the transaction
+* `maxFee`: sets the maximum fee to pay for the transaction
+* `priorityFee`: sets the priority fee to pay for the transaction
+* `gasPrice`: sets gas price to use for the (legacy) transaction
 
 ## Transaction receipts
 

--- a/src/interpreter/value.rs
+++ b/src/interpreter/value.rs
@@ -419,6 +419,13 @@ impl Value {
         }
     }
 
+    pub fn as_u128(&self) -> Result<u128> {
+        match self {
+            Value::Uint(n, _) => Ok(n.to()),
+            _ => bail!("cannot convert {} to u128", self.get_type()),
+        }
+    }
+
     pub fn as_u256(&self) -> Result<U256> {
         match self {
             Value::Uint(n, _) => Ok(n.to()),


### PR DESCRIPTION
Allows to set `gas`, `maxFee`, `priorityFee` and `gasPrice` using call options